### PR TITLE
Fixed Unnecessary duplication when using factors

### DIFF
--- a/R/pd.R
+++ b/R/pd.R
@@ -128,31 +128,7 @@ partial_dependence.rfsrc <- function(fit, data = NULL, var, cutoff = 10L, intera
     interaction <- FALSE
   if (class(y) == "data.frame")
     target <- unname(unlist(sapply(target, function(y) if (is.factor(data[[y]])) levels(data[[y]]) else y)))
-  
-  multi.cut <- F
-  if ("factor" %in% lapply(data[,var], class)){
-    if (length(var) == 1){
-      if(length(levels(data[,var])) != cutoff){
-        warning(paste("Levels of factor variable != cutoff. Adjusted cutoff to ", length(levels(data[,var])), sep=""))
-        cutoff <- length(levels(data[,var]))
-      }
-    } else {
-      multi.cut <- T
-      cutoff.new <- numeric(length(var))
-      for(ii in 1:length(var)){
-        if(class(data[,var[ii]]) ==  "factor")
-          cutoff.new[ii] <- length(levels(data[,var[ii]]))
-        else
-          cutoff.new[ii] <- cutoff
-      }
-      if(all(cutoff.new==cutoff.new[1]))
-        multi.cut <- F
-      else
-        cutoff <- cutoff.new 
-    }
-  }
-
-  
+    
   rng <- vector("list", length(var))
   names(rng) <- var
 


### PR DESCRIPTION
This checks for factor variables, and adjust the cutoffs so it doesn't create duplicate predictions, especially useful for when checking interactions. Example: In the previous version if you were going to generated PD for a continuous variable from Z=1:5 and a factor X=(Yes, No) and if the cutoff was 5, it would create 5^2 variables. (as it didn't realize it would do 5 levels for X even though there were only 2 proper levels). This version will automatically only create 10 predictions in such an instance: Z=1:5 when X=Yes, and Z=1:5 when X=No. 

It isn't exactly pretty. But it does work with the cases I tried. 